### PR TITLE
fix(Submenu): The Submenu now works as intended

### DIFF
--- a/CTkMenuBar/dropdown_menu.py
+++ b/CTkMenuBar/dropdown_menu.py
@@ -168,8 +168,6 @@ class CustomDropdownMenu(customtkinter.CTkFrame):
         submenu.is_submenu = True
         
         submenu.bind("<Enter>", lambda e, sub=self: self.change_hover(self), add="+")
-        submenuButtonSeed.bind("<Enter>", lambda e, sub=submenu, button=submenuButtonSeed: self.after(500, lambda: sub._show_submenu(self, button)), add="+")
-        submenuButtonSeed.bind("<Leave>", lambda e, sub=submenu: self.after(500, lambda: sub._left(self)), add="+")
         
         submenuButtonSeed.configure(cursor=self.cursor)
         
@@ -179,6 +177,20 @@ class CustomDropdownMenu(customtkinter.CTkFrame):
             expand=True,
             padx=3+(self.corner_radius/5),
             pady=3+(self.corner_radius/5))
+        
+        submenu._timer_id = None
+        def show_submenu_delayed():
+            if submenu._timer_id:
+                self.after_cancel(submenu._timer_id)
+            submenu._timer_id = self.after(500, lambda: submenu._show_submenu(self, submenuButtonSeed))
+        
+        def hide_submenu_delayed():
+            if submenu._timer_id:
+                self.after_cancel(submenu._timer_id)
+            submenu._timer_id = self.after(500, lambda: submenu._left(self))
+        
+        submenuButtonSeed.bind("<Enter>", lambda e: show_submenu_delayed(), add="+")
+        submenuButtonSeed.bind("<Leave>", lambda e: hide_submenu_delayed(), add="+")
         return submenu
         
     def _left(self, parent):


### PR DESCRIPTION
Submenus were automatically disappearing after exactly 1 second, even when the mouse cursor remained over the submenu or its trigger button. This issue only affected submenus - the main dropdown menus worked correctly.

- Removed duplicate event bindings that were causing timer conflicts
- Implemented proper timer management with cleanup of previous timers
- Single timer system that cancels previous timers before starting new ones

- [ x ]  Main dropdown menus still work correctly
- [ x ]  Submenus no longer auto-hide after 1 second
- [ x ]  Submenus properly hide when mouse leaves the area
- [ x ]  No timer conflicts or race conditions
- [ x ]  Hover behavior works as expected