### PR TITLE
Fix CTkTitleMenu dissallows having master be subclassed from customtkinter.CTkToplevel

### DIFF
--- a/CTkMenuBar/title_menu_win.py
+++ b/CTkMenuBar/title_menu_win.py
@@ -4,6 +4,7 @@ Author: Akash Bora
 """
 
 import customtkinter
+import tkinter as tk
 import sys
 
 class CTkTitleMenu(customtkinter.CTkToplevel):
@@ -34,6 +35,8 @@ class CTkTitleMenu(customtkinter.CTkToplevel):
             pass
         elif isinstance(self.master, customtkinter.CTkToplevel):
             pass        
+        elif isinstance(self.master, tk.Toplevel):
+            pass
         else:
             raise TypeError("Only root windows/toplevels can be passed as the master!")
         


### PR DESCRIPTION
### Problem

Adding a CTkTitleMenu with an instance of `customtkinter.CTkTopLevel` works as master, but adding it to an instance of a subclass of `customtkinter.CTkTopLevel` raises the TypeError "Only root windows/toplevels can be passed as the master!".

Because of the following code in CTkMenuBar.title_menu_win.CTkTitleMenu.\_\_init\_\_:
```py
master_type = self.master.winfo_name()
        
if master_type=="tk":
    pass
elif master_type.startswith("!ctktoplevel"):
    pass
elif master_type.startswith("!toplevel"):
    pass        
else:
    raise TypeError("Only root windows/toplevels can be passed as the master!")
```

Instances of subclasses of CTkTitleMenu do not have their .winfo_name() start with !ctktoplevel, but have their own unique name based on the class name. The following code demonstrates this:

```py
import customtkinter

import CTkMenuBar


class TopLevelSubclass(customtkinter.CTkToplevel):
    def __init__(self, master):
        super().__init__(master)


class Root(customtkinter.CTk):
    def __init__(self):
        super().__init__()

        self.top_level_object = customtkinter.CTkToplevel(self)
        self.top_level_subclass = TopLevelSubclass(self)


root = Root()

# Objects subclassed from 'customtkinter.CTkTopLevel' have their own unique winfo_name which does not start with !ctktoplevel

print(root.winfo_name())  # "tk"
print(root.top_level_object.winfo_name())  # "!ctktoplevel"  
print(root.top_level_subclass.winfo_name())  # "!toplevelsubclass"

# Isinstance is more appropriate, it does understand what's an instance or subclass, and what is not

print(isinstance(root, customtkinter.CTkToplevel))  # False
print(isinstance(root.top_level_object, customtkinter.CTkToplevel))  # True 
print(isinstance(root.top_level_subclass, customtkinter.CTkToplevel))  # True
```

### Solution

isinstance() accounts for subclasses of the given class. Adding
```py
elif isinstance(self.master, customtkinter.CTkToplevel):
    pass        
elif isinstance(self.master, tk.Toplevel):
    pass
```
solves the problem.

For testing, I checked that `example_titlemenu.py` still works. I don't think the project contains more tests to run.

### Further notes

I didn't remove the old conditions, even though to my knowledge the new conditions should also still catch the old ones, in case those account for some edge-case I haven't thought of. I am happy to remove them at your request.

Happy to hear if you need me to change something.

